### PR TITLE
Fix handling of combining characters and control characters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,6 +6,9 @@ History
 -----------
 
 * Improve encoding (~50%) and decoding (~25%) performance.
+* Fix handling of combining characters that occur at the end of a file or before
+  a control character. In those cases an implicit space (`U+0020`) is
+  introduced.
 
 
 0.1.1 (2018-12-31)

--- a/ansel/codec.py
+++ b/ansel/codec.py
@@ -8,6 +8,7 @@ class Codec(codecs.Codec):
     encode_char_map = {}
     encode_modifier_map = {}
     decode_char_map = {}
+    decode_control_map = {}
     decode_modifier_map = {}
 
     def encode(self, input, errors="strict"):
@@ -21,5 +22,6 @@ class Codec(codecs.Codec):
         decoder = IncrementalDecoder(errors)
         decoder.name = self.name
         decoder.decode_char_map = self.decode_char_map
+        decoder.decode_control_map = self.decode_control_map
         decoder.decode_modifier_map = self.decode_modifier_map
         return decoder.decode(input, final=True), len(input)

--- a/ansel/encodings/ansel.py
+++ b/ansel/encodings/ansel.py
@@ -2,7 +2,7 @@ import codecs
 
 from .. import codec, incremental
 
-ANSEL_TO_UNICODE = {
+ANSEL_TO_UNICODE_CONTROL = {
     0x00: "\u0000",  # NULL CHARACTER
     0x01: "\u0001",  # START OF HEADING
     0x02: "\u0002",  # START OF TEXT
@@ -35,6 +35,9 @@ ANSEL_TO_UNICODE = {
     0x1D: "\u001D",  # GROUP SEPARATOR
     0x1E: "\u001E",  # RECORD SEPARATOR
     0x1F: "\u001F",  # UNIT SEPARATOR
+}
+
+ANSEL_TO_UNICODE = {
     0x20: "\u0020",  # SPACE
     0x21: "\u0021",  # EXCLAMATION MARK
     0x22: "\u0022",  # QUOTATION MARK
@@ -823,12 +826,14 @@ class Codec(codec.Codec):
     encode_char_map = UNICODE_TO_ANSEL
     encode_modifier_map = UNICODE_TO_ANSEL_MODIFIERS
     decode_char_map = ANSEL_TO_UNICODE
+    decode_control_map = ANSEL_TO_UNICODE_CONTROL
     decode_modifier_map = ANSEL_TO_UNICODE_MODIFIERS
 
 
 class IncrementalDecoder(incremental.IncrementalDecoder):
     name = "ansel"
     decode_char_map = ANSEL_TO_UNICODE
+    decode_control_map = ANSEL_TO_UNICODE_CONTROL
     decode_modifier_map = ANSEL_TO_UNICODE_MODIFIERS
 
 

--- a/ansel/encodings/gedcom.py
+++ b/ansel/encodings/gedcom.py
@@ -3,6 +3,8 @@ import codecs
 from . import ansel
 from .. import codec, incremental
 
+GEDCOM_TO_UNICODE_CONTROL = ansel.ANSEL_TO_UNICODE_CONTROL
+
 GEDCOM_TO_UNICODE = ansel.ANSEL_TO_UNICODE.copy()
 GEDCOM_TO_UNICODE.update(
     {
@@ -40,12 +42,14 @@ class Codec(codec.Codec):
     encode_char_map = UNICODE_TO_GEDCOM
     encode_modifier_map = UNICODE_TO_GEDCOM_MODIFIERS
     decode_char_map = GEDCOM_TO_UNICODE
+    decode_control_map = GEDCOM_TO_UNICODE_CONTROL
     decode_modifier_map = GEDCOM_TO_UNICODE_MODIFIERS
 
 
 class IncrementalDecoder(incremental.IncrementalDecoder):
     name = "gedcom"
     decode_char_map = GEDCOM_TO_UNICODE
+    decode_control_map = GEDCOM_TO_UNICODE_CONTROL
     decode_modifier_map = GEDCOM_TO_UNICODE_MODIFIERS
 
 

--- a/tests/test_incremental.py
+++ b/tests/test_incremental.py
@@ -11,6 +11,7 @@ class IncrementalDecoder(ansel.incremental.IncrementalDecoder):
     decode_char_map = {ord(b"a"): "1", ord(b"b"): "23"}
     encode_modifier_map = {"n": b"5", "o": b"67"}
     decode_modifier_map = {ord(b"n"): "5", ord(b"o"): "67"}
+    decode_control_map = {ord(b"\n"): "8", ord(b"\t"): "9A"}
 
 
 class IncrementalEncoder(ansel.incremental.IncrementalEncoder):
@@ -201,6 +202,8 @@ def test_decode_valid(input, expected, expected_len):
         [b"an", b"nb"],
         [b"a", b"n", b"n", b"b"],
         [b"n", b"o"],
+        [b"a", b"n", b"\n"],
+        [b"b", b"o", b"\t", b"a"],
     ],
 )
 def test_decode_incremental(partials):
@@ -214,9 +217,9 @@ def test_decode_incremental(partials):
 @pytest.mark.parametrize(
     "input, expected, expected_len",
     [
-        (b"n", "5", 1),
-        (b"an", "15", 2),
-        (b"bn", "235", 2),
+        (b"n", " 5", 1),
+        (b"an", "1 5", 2),
+        (b"bn", "23 5", 2),
         (b"na", "15", 2),
         (b"naa", "151", 3),
         (b"noa", "1675", 3),
@@ -224,6 +227,36 @@ def test_decode_incremental(partials):
     ],
 )
 def test_decode_valid_with_modifiers(input, expected, expected_len):
+    decoder = IncrementalDecoder()
+    output = decoder.decode(input, final=True)
+    assert expected == output
+    assert (b"", 0) == decoder.getstate()
+
+
+@pytest.mark.parametrize(
+    "input, expected, expected_len",
+    [(b"\n", "8", 1), (b"\t", "9A", 1), (b"\n\t", "89A", 2)],
+)
+def test_decode_valid_with_control(input, expected, expected_len):
+    decoder = IncrementalDecoder()
+    output = decoder.decode(input)
+    assert expected == output
+    assert (b"", 0) == decoder.getstate()
+
+
+@pytest.mark.parametrize(
+    "input, expected, expected_len",
+    [
+        (b"n", " 5", 1),
+        (b"\nn", "8 5", 2),
+        (b"\tn", "9A 5", 2),
+        (b"n\n", " 58", 2),
+        (b"n\n\n", " 588", 3),
+        (b"no\n", " 6758", 3),
+        (b"on\t", " 5679A", 3),
+    ],
+)
+def test_decode_valid_with_control_modifiers(input, expected, expected_len):
     decoder = IncrementalDecoder()
     output = decoder.decode(input, final=True)
     assert expected == output


### PR DESCRIPTION
The ANSEL specification describes combining characters as:

> Nonspacing graphic character (combining character)-A graphic character whose
> use is not followed by the forward movement of the output device. For the
> purpose of this standard, the term includes character modifiers.

Given that interpretation, when a combining character is written to the output
stream, and isn't followed by a spacing character, it should implicitly be
treated as if a space character (`U+0020`) was written to the output device.
When this is translated to unicode, it will result in the combining characters
following the space character, which when rendered will appear as if the
combining characters alone were printed.

Fixes #9