### PR TITLE
Remove pytest-runner dependency

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -35,7 +35,6 @@ pyflakes==2.4.0
 Pygments==2.10.0
 pyparsing==2.4.7
 pytest==6.2.5
-pytest-runner==5.3.1
 pytz==2021.3
 readme-renderer==30.0
 regex==2021.11.10


### PR DESCRIPTION
pytest-runner has been deprecated and is no longer required to support other
dependencies

Fixes #109